### PR TITLE
Update IO.hs

### DIFF
--- a/Reliable/IO.hs
+++ b/Reliable/IO.hs
@@ -434,7 +434,7 @@ receivePacket (Endpoint epPtr _) pktPtr =
 getAcks :: Endpoint -> IO [Word16]
 getAcks (Endpoint epPtr _) = alloca $ \numAcksPtr -> do
     acksPtr <- c'reliable_endpoint_get_acks epPtr numAcksPtr
-    numAcks <- peek acksPtr
+    numAcks <- peek numAcksPtr
     peekArray (fromIntegral numAcks) acksPtr
 
 -- | Clears the list of sequence numbers for the most recently ack'd packets.


### PR DESCRIPTION
On line 437, the value for `numAcks` (which is supposed to tell how many elements should be read from the array pointed to by `acksPtr`) is read from the array at `acksPtr` instead of `numAcksPtr`. This patch fixes it.